### PR TITLE
Add power states for starting and stopping

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm.rb
@@ -28,9 +28,9 @@ class ManageIQ::Providers::Google::CloudManager::Vm < ManageIQ::Providers::Cloud
 
   def self.calculate_power_state(raw_power_state)
     case raw_power_state.downcase
-    when "running"
+    when /running/, /starting/
       "on"
-    when "terminated"
+    when /terminated/, /stopping/
       "off"
     else
       "unknown"


### PR DESCRIPTION
This will show starting and stopping instances as "on" or "off", right now they show up as "unknown" until they finish powering on/off.
